### PR TITLE
Vapor4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     products: [
         .library(name: "S3Kit", targets: ["S3Kit"]),
         .library(name: "S3Signer", targets: ["S3Signer"]),
-        //        .library(name: "S3TestTools", targets: ["S3TestTools"])
+        .library(name: "S3", targets: ["S3"])
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),

--- a/Sources/S3Kit/Extensions/S3+Request.swift
+++ b/Sources/S3Kit/Extensions/S3+Request.swift
@@ -1,10 +1,13 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import NIO
 import AsyncHTTPClient
 
 
 extension S3 {
-    
+
     /// Make an S3 request
     func make(request url: URL, method: HTTPMethod, headers: HTTPHeaders, data: Data? = nil, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy) -> EventLoopFuture<HTTPClient.Response> {
         do {
@@ -14,24 +17,24 @@ extension S3 {
             } else {
                 body = nil
             }
-            
+
             var headers = headers
             headers.add(name: "User-Agent", value: "S3Kit-for-Swift")
             headers.add(name: "Accept", value: "*/*")
             headers.add(name: "Connection", value: "keep-alive")
             headers.add(name: "Content-Length", value: String(data?.count ?? 0))
-            
+
             let request = try HTTPClient.Request(
                 url: url.absoluteString,
                 method: method,
                 headers: headers,
                 body: body
             )
-            
+
             return httpClient.execute(request: request, eventLoop: .delegate(on: eventLoop))
         } catch {
             return eventLoop.makeFailedFuture(error)
         }
     }
-    
+
 }


### PR DESCRIPTION
Fixed the following issues:
1. Added S3 product name to the package, so that we can use `.product(name: "S3", package: "S3Kit")` in the targets.
2. Fix issue `Use of undeclared type URLRequest` while building from the Linux machine. Added condition for `import FoundationNetworking`